### PR TITLE
Force feature value to be a string for info panel

### DIFF
--- a/src/components/info/features.component.js
+++ b/src/components/info/features.component.js
@@ -49,8 +49,8 @@ const Features = (props) => {
                 return (
                     <List.Item key={key} style={{ marginTop: -2 }}>
                         <Header as="h4">
-                            {features[key]}
-                            <Header.Subheader style={{ marginTop: 3, etterSpacing: 1 }}>[ {key} ]</Header.Subheader>
+                            {features[key].toString()}
+                            <Header.Subheader style={{ marginTop: 3, letterSpacing: 1 }}>[ {key} ]</Header.Subheader>
                         </Header>
                     </List.Item>
                 );


### PR DESCRIPTION
Hi! I was working on a project and set a feature value to an object instead of a string (it went from a hex code to a p5.Color). This REALLY upset the React component! 

I figured it would at least be better to have the features component render "Object [object]" than totally giving up on life. But I'm sure there are even more elegant solutions out there. 

Anyway, hope this helps!